### PR TITLE
トップページと華展作品一覧とのルーティングの実装

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,14 @@
+import Index from "./pages/Index";
+import Exhibition from "./pages/Exhibition";
+import { BrowserRouter, Route, Routes } from "react-router";
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Index />} />
+        <Route path="/exhibition/:id" element={<Exhibition />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./reset.css";
-import App from "./pages/Exhibition.tsx";
+import Index from "./pages/Index";
+import Exhibition from "./pages/Exhibition";
+import { BrowserRouter, Route, Routes } from "react-router";
 
 async function setup() {
   if (import.meta.env.VITE_MOCK_SERVER_ENABELD) {
@@ -15,7 +17,12 @@ async function setup() {
 setup().then(() => {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
-      <App />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/exhibition/:id" element={<Exhibition />} />
+        </Routes>
+      </BrowserRouter>
     </StrictMode>
   );
 });

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,9 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./reset.css";
-import Index from "./pages/Index";
-import Exhibition from "./pages/Exhibition";
-import { BrowserRouter, Route, Routes } from "react-router";
+import App from "./App";
 
 async function setup() {
   if (import.meta.env.VITE_MOCK_SERVER_ENABELD) {
@@ -17,12 +15,7 @@ async function setup() {
 setup().then(() => {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/exhibition/:id" element={<Exhibition />} />
-        </Routes>
-      </BrowserRouter>
+      <App />
     </StrictMode>
   );
 });

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -1,18 +1,17 @@
 import { type components } from "../types/api";
 import { works } from "../mocks/data/works";
 import { exhibitions } from "../mocks/data/exhibitions";
+import { useParams } from "react-router";
 import "./works.css"; // ToDo: CSS のインポートの変更
 
 type Work = components["schemas"]["Work"];
 type Exhibition = components["schemas"]["Exhibition"];
 
-const exhibition_id: number = 1; // ToDo: exhibition_id を URL パラメータから取得するように変更
-
 function getWorksForExhibition(exhibitionId: number): Work[] {
   return Object.values(works).filter((work) => work.exhibition_id === exhibitionId);
 }
 
-export function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
+function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
   if (!exhibition_id) {
     return <p>No exhibition selected.</p>;
   }
@@ -39,8 +38,15 @@ export function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
 }
 
 export default function Exhibition() {
+  const { id } = useParams();
+  const exhibition_id = Number(id); // ToDo: id が無効な値のときのエラーハンドリング
   return (
     <>
+      <header>
+        <nav>
+          <a href="/">ホームへ戻る</a>
+        </nav>
+      </header>
       <main>
         <h1>{exhibitions[exhibition_id].name}の作品一覧</h1>
         <ExhibitionImages exhibition_id={exhibition_id} />

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -3,6 +3,7 @@ import { works } from "../mocks/data/works";
 import { exhibitions } from "../mocks/data/exhibitions";
 import { useParams } from "react-router";
 import "./works.css"; // ToDo: CSS のインポートの変更
+import { Link } from "react-router";
 
 type Work = components["schemas"]["Work"];
 type Exhibition = components["schemas"]["Exhibition"];
@@ -44,7 +45,7 @@ export default function Exhibition() {
     <>
       <header>
         <nav>
-          <a href="/">ホームへ戻る</a>
+          <Link to="/">ホームへ戻る</Link>
         </nav>
       </header>
       <main>

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -10,7 +10,9 @@ function ExhibitionInfo({ exhibition }: { exhibition: Exhibition }) {
 
   return (
     <article>
-      <h3>{exhibition.name}</h3>
+      <h3>
+        <a href={"exhibition/" + exhibition.id}>{exhibition.name}</a>
+      </h3>
       <p>
         開催期間: {startedDate.toLocaleDateString("ja-JP")}-{endedDate.toLocaleDateString("ja-JP")}
       </p>

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { exhibitions } from "../mocks/data/exhibitions";
 import type { components } from "../types/api";
+import { Link } from "react-router";
 
 type Exhibition = components["schemas"]["Exhibition"];
 
@@ -11,7 +12,7 @@ function ExhibitionInfo({ exhibition }: { exhibition: Exhibition }) {
   return (
     <article>
       <h3>
-        <a href={"exhibition/" + exhibition.id}>{exhibition.name}</a>
+        <Link to={`exhibition/${exhibition.id}`}>{exhibition.name}</Link>
       </h3>
       <p>
         開催期間: {startedDate.toLocaleDateString("ja-JP")}-{endedDate.toLocaleDateString("ja-JP")}


### PR DESCRIPTION
@seekseep トップページと華展作品一覧ページ間のルーティングのみタスクを切り出して、実装してみました。
以下の観点でレビューをお願いします。

- [これ](https://github.com/study-basic-hackathon/album/issues/111#issuecomment-2961902600) が満たせているか
- ベストプラクティスとの大きな乖離がないか

## 動作確認方法

`npm run dev` -> `http://localhost:5173` をブラウザで見るだけで確認できるはずです。