### PR TITLE
FROMの後の無駄スペースの削除

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -206,7 +206,7 @@ app.get("/arrangers/:arrangerId/works", async (req, res) => {
         wk.season_id,
         ARRAY_AGG(DISTINCT ie.url) AS image_urls,
         TO_CHAR(wk.created_at, 'YYYY-MM-DD HH24:MI:SS') AS created_at
-      FROM  
+      FROM
         work AS wk
       JOIN
         work_material AS wm ON wk.id = wm.work_id


### PR DESCRIPTION
 #126 と関連

- 上記において、「作者の作品の一覧」のSQL文で、FROMの後に半角空白を2回入力してしまったため、削除した