### PR TITLE
華展作品一覧ページで API を使用

### DIFF
--- a/client/src/api/exhibition.ts
+++ b/client/src/api/exhibition.ts
@@ -57,7 +57,7 @@ export function useExhibition(exhibitionId: number): Exhibition | null {
         const fetchedExhibition = await getExhibition(exhibitionId);
         setExhibition(fetchedExhibition);
       } catch (error) {
-        console.error(`Failed to fetch exhibition ${exhibitionId}:`, error); 
+        console.error(`Failed to fetch exhibition ${exhibitionId}:`, error);
         setExhibition(null); // エラー時は null を設定
       }
     }
@@ -83,7 +83,7 @@ export async function listExhibitionWorks(
 }
 
 export function useExhibitionWorks(exhibitionId: number): Record<number, WorkListItem> {
-  const [works, setWorks] = useState<Record<number, WorkListItem>>([]);
+  const [works, setWorks] = useState<Record<number, WorkListItem>>({});
   useEffect(() => {
     async function fetchedWorks() {
       try {

--- a/client/src/api/exhibition.ts
+++ b/client/src/api/exhibition.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { type components } from "../types/api";
 
 type Exhibition = components["schemas"]["Exhibition"];
+type WorkListItem = components["schemas"]["WorkListItem"];
 
 export async function listExhibitions(): Promise<
   paths["/exhibitions"]["get"]["responses"]["200"]["content"]["application/json"]
@@ -30,4 +31,70 @@ export function useExhibitions(): Record<number, Exhibition> {
     fetchedExhibitions();
   }, []);
   return exhibitions;
+}
+
+export async function getExhibition(
+  exhibitionId: number
+): Promise<
+  paths["/exhibitions/{exhibitionId}"]["get"]["responses"]["200"]["content"]["application/json"]
+> {
+  const path = endpoint("/exhibitions/{exhibitionId}").replace(
+    "{exhibitionId}",
+    String(exhibitionId)
+  );
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch exhibition with ID ${exhibitionId}`);
+  }
+  return response.json();
+}
+
+export function useExhibition(exhibitionId: number): Exhibition | null {
+  const [exhibition, setExhibition] = useState<Exhibition | null>(null);
+  useEffect(() => {
+    async function fetchedExhibition() {
+      try {
+        const fetchedExhibition = await getExhibition(exhibitionId);
+        setExhibition(fetchedExhibition);
+      } catch (error) {
+        console.error(`Failed to fetch exhibition ${exhibitionId}:`, error); 
+        setExhibition(null); // エラー時は null を設定
+      }
+    }
+    fetchedExhibition();
+  }, [exhibitionId]);
+  return exhibition;
+}
+
+export async function listExhibitionWorks(
+  exhibitionId: number
+): Promise<
+  paths["/exhibitions/{exhibitionId}/works"]["get"]["responses"]["200"]["content"]["application/json"]
+> {
+  const path = endpoint(`/exhibitions/{exhibitionId}/works`).replace(
+    "{exhibitionId}",
+    String(exhibitionId)
+  );
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch works for exhibition with ID ${exhibitionId}`);
+  }
+  return response.json();
+}
+
+export function useExhibitionWorks(exhibitionId: number): Record<number, WorkListItem> {
+  const [works, setWorks] = useState<Record<number, WorkListItem>>([]);
+  useEffect(() => {
+    async function fetchedWorks() {
+      try {
+        const fetchedWorks = await listExhibitionWorks(exhibitionId);
+        setWorks(fetchedWorks);
+      } catch (error) {
+        console.error(`Failed to fetch works for exhibition ${exhibitionId}:`, error);
+        setWorks([]); // エラー時は空の配列を設定
+      }
+    }
+    fetchedWorks();
+  }, [exhibitionId]);
+  return works;
 }

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -26,7 +26,7 @@ function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
                 <img
                   className="works-image-list__image"
                   key={index}
-                  src={work.image_urls[0]}
+                  src={`${import.meta.env.VITE_API_BASE_URL}/works/${work.image_ids[0]}`}
                   alt={work.title ? work.title : "無題の作品"}
                 />
               </Link>

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -1,26 +1,17 @@
 import { type components } from "../types/api";
-import { works } from "../mocks/data/works";
-import { exhibitions } from "../mocks/data/exhibitions";
 import "./works.css"; // ToDo: CSS のインポートの変更
 import { Link, useParams } from "react-router";
+import { useExhibition, useExhibitionWorks } from "../api/exhibition";
 
-type Work = components["schemas"]["Work"];
 type Exhibition = components["schemas"]["Exhibition"];
+type Work = components["schemas"]["Work"];
 
-function getWorksForExhibition(exhibitionId: number): Work[] {
-  return Object.values(works).filter((work) => work.exhibition_id === exhibitionId);
-}
-
-function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
-  if (!exhibition_id) {
-    return <p>No exhibition selected.</p>;
-  }
-  const exhibitionWorks = getWorksForExhibition(exhibition_id);
+function ExhibitionImages({ exhibition_works }: { exhibition_works: Work[] }) {
   return (
     <>
       <div>
         <ul role="list" className="works-image-list">
-          {exhibitionWorks.map((work, index) => (
+          {exhibition_works.map((work, index) => (
             <li>
               <Link to={`work/${work.id}`}>
                 <img
@@ -41,13 +32,25 @@ function ExhibitionImages({ exhibition_id }: { exhibition_id: number }) {
 
 export default function Exhibition() {
   const params = useParams();
-  const exhibition_id = Number(params.exhibition_id); // ToDo: exhibition_id が無効な値のときのエラーハンドリング
+  const exhibition_id = Number(params.exhibition_id);
+  const exhibition = useExhibition(exhibition_id);
+  const exhibition_works: Work[] = Object.values(useExhibitionWorks(exhibition_id)).map(
+    (item) => item.work
+  );
+
+  if (!exhibition) {
+    return (
+      <main>
+        <h1>指定された華展は存在しません</h1>
+      </main>
+    );
+  }
 
   return (
     <>
       <main>
-        <h1>{exhibitions[exhibition_id].name}の作品一覧</h1>
-        <ExhibitionImages exhibition_id={exhibition_id} />
+        <h1>{`${exhibition.name}の作品一覧`}</h1>
+        <ExhibitionImages exhibition_works={exhibition_works} />
       </main>
     </>
   );

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -6,12 +6,12 @@ import { useExhibition, useExhibitionWorks } from "../api/exhibition";
 type Exhibition = components["schemas"]["Exhibition"];
 type Work = components["schemas"]["Work"];
 
-function ExhibitionImages({ exhibition_works }: { exhibition_works: Work[] }) {
+function ExhibitionImages({ exhibitionWorks }: { exhibitionWorks: Work[] }) {
   return (
     <>
       <div>
         <ul role="list" className="works-image-list">
-          {exhibition_works.map((work, index) => (
+          {exhibitionWorks.map((work, index) => (
             <li key={index}>
               <Link to={`work/${work.id}`}>
                 <img
@@ -33,7 +33,7 @@ export default function Exhibition() {
   const params = useParams();
   const exhibition_id = Number(params.exhibition_id);
   const exhibition = useExhibition(exhibition_id);
-  const exhibition_works: Work[] = Object.values(useExhibitionWorks(exhibition_id)).map(
+  const exhibitionWorks: Work[] = Object.values(useExhibitionWorks(exhibition_id)).map(
     (item) => item.work
   );
 
@@ -49,7 +49,7 @@ export default function Exhibition() {
     <>
       <main>
         <h1>{`${exhibition.name}の作品一覧`}</h1>
-        <ExhibitionImages exhibition_works={exhibition_works} />
+        <ExhibitionImages exhibitionWorks={exhibitionWorks} />
       </main>
     </>
   );

--- a/client/src/pages/Exhibition.tsx
+++ b/client/src/pages/Exhibition.tsx
@@ -12,11 +12,10 @@ function ExhibitionImages({ exhibition_works }: { exhibition_works: Work[] }) {
       <div>
         <ul role="list" className="works-image-list">
           {exhibition_works.map((work, index) => (
-            <li>
+            <li key={index}>
               <Link to={`work/${work.id}`}>
                 <img
                   className="works-image-list__image"
-                  key={index}
                   src={`${import.meta.env.VITE_API_BASE_URL}/works/${work.image_ids[0]}`}
                   alt={work.title ? work.title : "無題の作品"}
                 />


### PR DESCRIPTION
この段階では、トップページ `Index.tsx` と華展作品一覧 `Exhibition.tsx` でのみ API を叩いてデータを取得しています。