### PR TITLE
Postを6つのAPIで実装した

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -5,7 +5,7 @@ import arrangerRoutes from './routers/arranger.js';
 import materialRoutes from './routers/material.js';
 import categoryRoutes from './routers/category.js';
 import seasonRoutes from './routers/season.js';
-import imageRoutes from './routers/image.js'
+import imageRoutes from './routers/image.js';
 import workRoutes from './routers/work.js';
 
 const app = express();

--- a/api/src/repositories/arranger.js
+++ b/api/src/repositories/arranger.js
@@ -1,6 +1,22 @@
 import { pool } from "../db.js";
 import { getFormattedWorkListByCondition } from "./formattedWorkList.js";
 
+//作者の登録
+export async function postArrangerByName(name) {
+  const result = await pool.query(
+    `
+    INSERT INTO
+       arranger (name)
+     VALUES
+       ($1)
+     RETURNING
+       id
+    `,
+    [name]
+  );
+  return result.rows;
+}
+
 export async function findArrangerById(arrangerId) {
   const result = await pool.query(
     `

--- a/api/src/repositories/category.js
+++ b/api/src/repositories/category.js
@@ -1,6 +1,22 @@
 import { pool } from "../db.js";
 import { getFormattedWorkListByCondition } from "./formattedWorkList.js";
 
+//カテゴリの登録
+export async function postCategoryByName(name) {
+  const result = await pool.query(
+    `
+    INSERT INTO
+       category (name)
+     VALUES
+       ($1)
+     RETURNING
+       id
+    `,
+    [name]
+  );
+  return result.rows;
+}
+
 export async function findCategoryById(categoryId) {
   const result = await pool.query(
     `

--- a/api/src/repositories/exhibition.js
+++ b/api/src/repositories/exhibition.js
@@ -16,6 +16,22 @@ export async function findAllExhibitions() {
     return result.rows;
 };
 
+//華展の登録
+export async function postExhibitionByName(name, started_date, ended_date) {
+  const result = await pool.query(
+    `
+    INSERT INTO
+       exhibition ( name, started_name, ended_date )
+     VALUES
+       ($1,$2,$3)
+     RETURNING
+       id
+    `,
+    [name, started_date, ended_date]
+  );
+  return result.rows;
+};
+
 export async function findExhibitionById(exhibitionId) {
     const result = await pool.query(`
       SELECT

--- a/api/src/repositories/material.js
+++ b/api/src/repositories/material.js
@@ -1,6 +1,22 @@
 import { pool } from "../db.js";
 import { getFormattedWorkListByCondition } from "./formattedWorkList.js";
 
+//花材の登録
+export async function postMaterialByName(name) {
+  const result = await pool.query(
+    `
+    INSERT INTO
+       material (name)
+     VALUES
+       ($1)
+     RETURNING
+       id
+    `,
+    [name]
+  );
+  return result.rows;
+}
+
 export async function findMaterialById(materialId) {
     const result = await pool.query(`
       SELECT

--- a/api/src/repositories/season.js
+++ b/api/src/repositories/season.js
@@ -1,6 +1,22 @@
 import { pool } from "../db.js";
 import { getFormattedWorkListByCondition } from "./formattedWorkList.js";
 
+//季節の登録
+export async function postSeasonByName(name) {
+  const result = await pool.query(
+    `
+    INSERT INTO
+       seasonS (name)
+     VALUES
+       ($1)
+     RETURNING
+       id
+    `,
+    [name]
+  );
+  return result.rows;
+}
+
 export async function findSeasonById(seasonId) {
     const result = await pool.query(`
       SELECT

--- a/api/src/repositories/work.js
+++ b/api/src/repositories/work.js
@@ -1,5 +1,59 @@
 import { pool } from "../db.js";
 
+// 作品の登録
+export async function postWork(title, arranger_id, material_ids, season_id, category_id, image_ids) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // work テーブルに作品情報を登録
+    const workResult = await client.query(
+      `
+      INSERT INTO
+          work(title, arranger_id, season_id, category_id)
+      VALUES
+          ($1, $2, $3, $4)
+      RETURNING
+          id
+      `,
+      [title, arranger_id, season_id, category_id]
+    );
+
+    const workId = workResult.rows[0].id;
+
+    // material_work 中間テーブルにデータを登録
+    if (material_ids && material_ids.length > 0) {
+      const materialInserts = material_ids.map(materialId => `(${workId}, ${materialId})`).join(',');
+      await client.query(`
+        INSERT INTO
+            material_work(work_id, material_id)
+        VALUES
+            ${materialInserts}
+      `);
+    }
+
+    // image_work 中間テーブルにデータを登録
+    if (image_ids && image_ids.length > 0) {
+      const imageInserts = image_ids.map(imageId => `(${workId}, ${imageId})`).join(',');
+      await client.query(`
+        INSERT INTO
+            image_work(work_id, image_id)
+        VALUES
+            ${imageInserts}
+      `);
+    }
+
+    await client.query('COMMIT');
+    return workId;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('Error registering data:', error);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 // 作品の更新
 export async function updateWorkBase(workId, title, arranger_id, season_id, category_id) {
     const result = await pool.query(`

--- a/api/src/routers/arranger.js
+++ b/api/src/routers/arranger.js
@@ -1,5 +1,6 @@
 import express from "express";
 import {
+  getArrangerPath,
   getArrangerById,
   getArrangerWorks,
   getArrangerWorkById,
@@ -8,6 +9,27 @@ import {
 } from "../usecases/arranger.js";
 
 const router = express.Router();
+
+//作者の登録
+router.post("/", async (req, res) => {
+  try {
+    const { name } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!name) {
+      return res.status(400).send({ message: 'Name is required' });
+    }
+    if (forbiddenChars.test(name)) {
+      return res.status(400).json({ message: "Invalid Name" });
+    }
+    const result = await getArrangerPath(name);
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'Arranger created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 // 作者の情報の取得
 router.get("/:arrangerId", async (req, res) => {

--- a/api/src/routers/category.js
+++ b/api/src/routers/category.js
@@ -1,7 +1,35 @@
 import express from "express";
-import { getCategoryById, getCategoryWorks, getCategoryWorkById, updateCategory, deleteCategory } from '../usecases/category.js';
+import { 
+  getCategoryPath,
+  getCategoryById, 
+  getCategoryWorks, 
+  getCategoryWorkById, 
+  updateCategory, 
+  deleteCategory 
+} from '../usecases/category.js';
 
 const router = express.Router();
+
+//カテゴリの登録
+router.post("/", async (req, res) => {
+  try {
+    const { name } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!name) {
+      return res.status(400).send({ message: 'Name is required' });
+    }
+    if (forbiddenChars.test(name)) {
+      return res.status(400).json({ message: "Invalid Name" });
+    }
+    const result = await getCategoryPath(name);
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'Category created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 // カテゴリーの情報の取得
 router.get("/:categoryId", async (req, res) => {

--- a/api/src/routers/exhibition.js
+++ b/api/src/routers/exhibition.js
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   getExhibitions,
+  getExhibitionPath,
   getExhibitionById,
   getExhibitionWorks,
   getExhibitionWorkById,
@@ -19,6 +20,36 @@ router.get("/", async (req, res) => {
     console.error("Error:", err);
     res.status(500).json({ error: "Internal Server Error" });
   };
+});
+
+//華展の登録
+router.post("/", async (req, res) => {
+  try {
+    const { name, started_date, ended_date } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!name) {
+      return res.status(400).send({ message: 'Name is required' });
+    }
+    if (forbiddenChars.test(name)) {
+      return res.status(400).json({ message: "Invalid Name" });
+    }
+    if (!started_date || new Date(started_date).toString() === 'Invalid Date') {
+      return res.status(400).json({ message: 'Invalid started_date' })
+    }
+    if (!ended_date || new Date(ended_date).toString() === 'Invalid Date') {
+      return res.status(400).json({ message: 'Invalid ended_date' });
+    }
+    if (new Date(started_date) > new Date(ended_date)) {
+      return res.status(400).json({ message: 'started_date cannot be after ended_date.' });
+    }
+    const result = await getExhibitionPath( name, started_date, ended_date );
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'Exhibition created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
 });
 
 // 華展の情報の取得

--- a/api/src/routers/material.js
+++ b/api/src/routers/material.js
@@ -1,7 +1,35 @@
 import express from "express";
-import { getMaterialById, getMaterialWorks, getMaterialWorkById, updateMaterial, deleteMaterial } from '../usecases/material.js';
+import {
+  getMaterialPath,
+  getMaterialById, 
+  getMaterialWorks, 
+  getMaterialWorkById, 
+  updateMaterial, 
+  deleteMaterial,  
+} from '../usecases/material.js';
 
 const router = express.Router();
+
+//花材の登録
+router.post("/", async (req, res) => {
+  try {
+    const { name } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!name) {
+      return res.status(400).send({ message: 'Name is required' });
+    }
+    if (forbiddenChars.test(name)) {
+      return res.status(400).json({ message: "Invalid Name" });
+    }
+    const result = await getMaterialPath(name);
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'material created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 // 花材の情報の取得
 router.get("/:materialId", async (req, res) => {

--- a/api/src/routers/season.js
+++ b/api/src/routers/season.js
@@ -1,7 +1,34 @@
 import express from "express";
-import { getSeasonById, getSeasonWorks, getSeasonWorkById, updateSeason, deleteSeason } from '../usecases/season.js';
+import { 
+  getSeasonPath,
+  getSeasonById, 
+  getSeasonWorks, 
+  getSeasonWorkById, 
+  updateSeason, 
+  deleteSeason } from '../usecases/season.js';
 
 const router = express.Router();
+
+//季節の登録
+router.post("/", async (req, res) => {
+  try {
+    const { name } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!name) {
+      return res.status(400).send({ message: 'Name is required' });
+    }
+    if (forbiddenChars.test(name)) {
+      return res.status(400).json({ message: "Invalid Name" });
+    }
+    const result = await getSeasonPath(name);
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'season created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 // 季節の情報の取得
 router.get("/:seasonId", async (req, res) => {

--- a/api/src/routers/work.js
+++ b/api/src/routers/work.js
@@ -1,7 +1,29 @@
 import express from "express";
-import { updateWork, deleteWork } from "../repositories/work.js";
+import { updateWork, deleteWork, getWorkPath } from "../repositories/work.js";
 
 const router = express.Router();
+
+//作品の登録
+router.post("/", async (req, res) => {
+  try {
+    const { arranger_id, material_ids, season_id, category_id, image_ids } = req.params;
+    const { title } = req.body;
+    const forbiddenChars = /[<>{}[\]|\\^`$"'=]/;
+    if (!title) {
+      return res.status(400).send({ message: 'title is required' });
+    }
+    if (forbiddenChars.test(title)) {
+      return res.status(400).json({ message: "Invalid title" });
+    }
+    const result = await getWorkPath(title, arranger_id, material_ids, season_id, category_id, image_ids);
+    res.status(201)
+      .header('Location', result)
+      .send({ message: 'season created', path: result });
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 // 作品の更新
 router.put("/:workId", async (req, res) => {

--- a/api/src/usecases/arranger.js
+++ b/api/src/usecases/arranger.js
@@ -1,9 +1,9 @@
-import { findArrangerById, findWorksByArrangerId, postArrangerByName } from '../repositories/arranger.js';
+import { findArrangerById, findWorksByArrangerId, postArranger } from '../repositories/arranger.js';
 import * as arrangerRepository from '../repositories/arranger.js';
 
 //作者の登録
 export async function getArrangerPath(name) {
-  const resultRows = await postArrangerByName(name);
+  const resultRows = await postArranger(name);
   const arrangerId = resultRows[0].id;
   const path = `/arrangers/${arrangerId}`;
   return path;

--- a/api/src/usecases/arranger.js
+++ b/api/src/usecases/arranger.js
@@ -1,5 +1,13 @@
-import { findArrangerById, findWorksByArrangerId } from '../repositories/arranger.js';
+import { findArrangerById, findWorksByArrangerId, postArrangerByName } from '../repositories/arranger.js';
 import * as arrangerRepository from '../repositories/arranger.js';
+
+//作者の登録
+export async function getArrangerPath(name) {
+  const resultRows = await postArrangerByName(name);
+  const arrangerId = resultRows[0].id;
+  const path = `/arrangers/${arrangerId}`;
+  return path;
+};
 
 // 作者の情報の取得
 export async function getArrangerById(arrangerId) {

--- a/api/src/usecases/category.js
+++ b/api/src/usecases/category.js
@@ -1,5 +1,14 @@
-import { findCategoryById, findWorksByCategoryId } from '../repositories/category.js';
+import { findCategoryById, findWorksByCategoryId, postCategoryByName } from '../repositories/category.js';
 import * as categoryRepository from '../repositories/category.js';
+
+//カテゴリの登録
+export async function getCategoryPath(name) {
+  const resultRows = await postCategoryByName(name);
+  const categoryId = resultRows[0].id;
+  const path = `/categories/${categoryId}`;
+  return path;
+};
+
 
 // カテゴリーの情報の取得
 export async function getCategoryById(categoryId) {

--- a/api/src/usecases/category.js
+++ b/api/src/usecases/category.js
@@ -1,9 +1,9 @@
-import { findCategoryById, findWorksByCategoryId, postCategoryByName } from '../repositories/category.js';
+import { findCategoryById, findWorksByCategoryId, postCategory } from '../repositories/category.js';
 import * as categoryRepository from '../repositories/category.js';
 
 //カテゴリの登録
 export async function getCategoryPath(name) {
-  const resultRows = await postCategoryByName(name);
+  const resultRows = await postCategory(name);
   const categoryId = resultRows[0].id;
   const path = `/categories/${categoryId}`;
   return path;

--- a/api/src/usecases/exhibition.js
+++ b/api/src/usecases/exhibition.js
@@ -1,6 +1,6 @@
 import { 
   findAllExhibitions, 
-  postExhibitionByName, 
+  postExhibition, 
   findExhibitionById, 
   findWorksByExhibitionId 
 } from '../repositories/exhibition.js';
@@ -14,7 +14,7 @@ export async function getExhibitions() {
 
 //作者の登録
 export async function getExhibitionPath(name, started_date, ended_date) {
-  const resultRows = await postExhibitionByName(name, started_date, ended_date);
+  const resultRows = await postExhibition(name, started_date, ended_date);
   const exhibitionId = resultRows[0].id;
   const path = `/exhibitions/${exhibitionId}`;
   return path;

--- a/api/src/usecases/exhibition.js
+++ b/api/src/usecases/exhibition.js
@@ -1,10 +1,23 @@
-import { findAllExhibitions, findExhibitionById, findWorksByExhibitionId } from '../repositories/exhibition.js';
+import { 
+  findAllExhibitions, 
+  postExhibitionByName, 
+  findExhibitionById, 
+  findWorksByExhibitionId 
+} from '../repositories/exhibition.js';
 import * as exhibitionRepository from '../repositories/exhibition.js';
 
 // 華展の一覧
 export async function getExhibitions() {
   const result = await findAllExhibitions();
   return result;
+};
+
+//作者の登録
+export async function getExhibitionPath(name, started_date, ended_date) {
+  const resultRows = await postExhibitionByName(name, started_date, ended_date);
+  const exhibitionId = resultRows[0].id;
+  const path = `/exhibitions/${exhibitionId}`;
+  return path;
 };
 
 // 華展の取得

--- a/api/src/usecases/material.js
+++ b/api/src/usecases/material.js
@@ -1,5 +1,13 @@
-import { findMaterialById, findWorksByMaterialId } from '../repositories/material.js';
+import { findMaterialById, findWorksByMaterialId, postMaterialByName } from '../repositories/material.js';
 import * as materialRepository from '../repositories/material.js';
+
+//作者の登録
+export async function getMaterialPath(name) {
+  const resultRows = await postMaterialByName(name);
+  const materialId = resultRows[0].id;
+  const path = `/materials/${materialId}`;
+  return path;
+};
 
 // 花材の情報の取得
 export async function getMaterialById(materialId) {

--- a/api/src/usecases/material.js
+++ b/api/src/usecases/material.js
@@ -1,9 +1,9 @@
-import { findMaterialById, findWorksByMaterialId, postMaterialByName } from '../repositories/material.js';
+import { findMaterialById, findWorksByMaterialId, postMaterial } from '../repositories/material.js';
 import * as materialRepository from '../repositories/material.js';
 
 //作者の登録
 export async function getMaterialPath(name) {
-  const resultRows = await postMaterialByName(name);
+  const resultRows = await postMaterial(name);
   const materialId = resultRows[0].id;
   const path = `/materials/${materialId}`;
   return path;

--- a/api/src/usecases/season.js
+++ b/api/src/usecases/season.js
@@ -1,9 +1,9 @@
-import { findSeasonById, findWorksBySeasonId, postSeasonByName } from '../repositories/season.js';
+import { findSeasonById, findWorksBySeasonId, postSeason } from '../repositories/season.js';
 import * as seasonRepository from '../repositories/season.js';
 
 //作者の登録
 export async function getSeasonPath(name) {
-  const resultRows = await postSeasonByName(name);
+  const resultRows = await postSeason(name);
   const seasonId = resultRows[0].id;
   const path = `/seasons/${seasonId}`;
   return path;

--- a/api/src/usecases/season.js
+++ b/api/src/usecases/season.js
@@ -1,5 +1,13 @@
-import { findSeasonById, findWorksBySeasonId } from '../repositories/season.js';
+import { findSeasonById, findWorksBySeasonId, postSeasonByName } from '../repositories/season.js';
 import * as seasonRepository from '../repositories/season.js';
+
+//作者の登録
+export async function getSeasonPath(name) {
+  const resultRows = await postSeasonByName(name);
+  const seasonId = resultRows[0].id;
+  const path = `/seasons/${seasonId}`;
+  return path;
+};
 
 // 季節の情報の取得
 export async function getSeasonById(seasonId) {

--- a/api/src/usecases/work.js
+++ b/api/src/usecases/work.js
@@ -1,4 +1,13 @@
+import { postWork } from '../repositories/work.js';
 import * as workRepository from '../repositories/work.js';
+
+// 作品の登録
+export async function getWorkPath(title, arranger_id, material_ids, season_id, category_id, image_ids) {
+    const resultRows = await postWork(title, arranger_id, material_ids, season_id, category_id, image_ids);
+    const workId = resultRows[0].id;
+    const path = `/works/${workId}`;
+    return path;
+}
 
 // 作品の更新
 export async function updateWork(workId, title, arranger_id, material_ids, season_id, category_id, image_ids) {


### PR DESCRIPTION
### 下記のエンドポイントにおいて、post処理を実装した
- `exhibitions/`
- `arrangers/`
- `materials/`
- `categories/`
- `season/`
- `works/`

`works/`のみ、複合キーテーブルであるimageとwork_materialも、新規のデータを登録する必要がある。
登録の不整合を回避するため、全てのテーブルで登録できない限り、ロールバックするようにした。(下記参照)

```js
// 作品の登録
export async function postWork(title, arranger_id, material_ids, season_id, category_id, image_ids) {
  const client = await pool.connect();
  try {
    await client.query('BEGIN');

    // work テーブルに作品情報を登録
    const workResult = await client.query(
      `
      INSERT INTO
          work(title, arranger_id, season_id, category_id)
      VALUES
          ($1, $2, $3, $4)
      RETURNING
          id
      `,
      [title, arranger_id, season_id, category_id]
    );

    const workId = workResult.rows[0].id;

    // material_work 中間テーブルにデータを登録
    if (material_ids && material_ids.length > 0) {
      const materialInserts = material_ids.map(materialId => `(${workId}, ${materialId})`).join(',');
      await client.query(`
        INSERT INTO
            material_work(work_id, material_id)
        VALUES
            ${materialInserts}
      `);
    }

    // image_work 中間テーブルにデータを登録
    if (image_ids && image_ids.length > 0) {
      const imageInserts = image_ids.map(imageId => `(${workId}, ${imageId})`).join(',');
      await client.query(`
        INSERT INTO
            image_work(work_id, image_id)
        VALUES
            ${imageInserts}
      `);
    }

    await client.query('COMMIT');
    return workId;
  } catch (error) {
    await client.query('ROLLBACK');
    console.error('Error registering data:', error);
    throw error;
  } finally {
    client.release();
  }
}
‘‘‘

close #170 