### PR TITLE
imageAPIのdelete処理実装

### DIFF
--- a/api/src/repositories/image.js
+++ b/api/src/repositories/image.js
@@ -1,6 +1,6 @@
 import { pool } from "../db.js";
 import path from 'path';
-import {promises as fs} from 'fs';
+import { promises as fs } from 'fs';
 import { noRecord, success, rollbackError } from '../utils/image.js'
 
 const UPLAODS_DIRECTORY = process.env.UPLAODS_DIRECTORY || "uploads";

--- a/api/src/repositories/image.js
+++ b/api/src/repositories/image.js
@@ -1,5 +1,7 @@
+import { pool } from "../db.js";
 import path from 'path';
-import fs from 'fs';
+import {promises as fs} from 'fs';
+import { noRecord, success, rollbackError } from '../utils/image.js'
 
 const UPLAODS_DIRECTORY = process.env.UPLAODS_DIRECTORY || "uploads";
 
@@ -16,4 +18,49 @@ export function findImageById(imageId) {
   };
   const filePath = path.join(uploadDir, foundFileName);
     return filePath;
+};
+
+export async function deleteImageTransaction(imageId, filePath){
+  let client; 
+  try {
+    client = await pool.connect();
+    await client.query('BEGIN');
+
+    // レコードを削除
+    const result = await client.query(
+    `DELETE FROM
+      images
+    WHERE
+      id = $1`,
+     [imageId]
+    );
+
+    if (result.rowCount === 0) {
+      await client.query('ROLLBACK');
+      console.warn(`image record not found`);
+      return noRecord;
+    }
+
+    // ファイルを削除
+    await fs.unlink(filePath);
+    await client.query('COMMIT');
+    return success;
+
+  } catch (error) {
+    console.error(`Error:`, error);
+
+    // ロールバック時にエラーが生じる可能性もある
+    if (client) {
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackError) {
+        console.error(`Error during rollback:`, rollbackError);
+      }
+    }
+    return rollbackError;
+  } finally {
+    if (client) {
+      client.release();
+    }
+  }
 };

--- a/api/src/repositories/image.js
+++ b/api/src/repositories/image.js
@@ -1,7 +1,7 @@
 import { pool } from "../db.js";
 import path from 'path';
 import { promises as fs } from 'fs';
-import { noRecord, success, rollbackError } from '../utils/image.js'
+import { noRecord, success } from '../utils/image.js'
 
 const UPLAODS_DIRECTORY = process.env.UPLAODS_DIRECTORY || "uploads";
 
@@ -47,20 +47,10 @@ export async function deleteImageTransaction(imageId, filePath){
     return success;
 
   } catch (error) {
-    console.error(`Error:`, error);
-
-    // ロールバック時にエラーが生じる可能性もある
-    if (client) {
-      try {
-        await client.query('ROLLBACK');
-      } catch (rollbackError) {
-        console.error(`Error during rollback:`, rollbackError);
-      }
-    }
-    return rollbackError;
+    await client.query('ROLLBACK');
+    console.error(`Error deleting data:`, error);
+    throw error;
   } finally {
-    if (client) {
-      client.release();
-    }
+    client.release();
   }
 };

--- a/api/src/repositories/image.js
+++ b/api/src/repositories/image.js
@@ -42,15 +42,21 @@ export async function deleteImageTransaction(imageId, filePath){
     }
 
     // ファイルを削除
-    await fs.unlink(filePath);
+    try {
+      await fs.unlink(filePath);
+    } catch (err) {
+      console.error(`failed to delete file:`, err);
+      throw err;
+    }
+
     await client.query('COMMIT');
     return success;
 
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error(`Error deleting data:`, error);
-    throw error;
+  } catch (err) {
+    if (client) await client.query('ROLLBACK');
+    console.error(`failed to complete transaction:`, err);
+    throw err;
   } finally {
-    client.release();
+    if (client) client.release();
   }
 };

--- a/api/src/repositories/image.js
+++ b/api/src/repositories/image.js
@@ -29,7 +29,7 @@ export async function deleteImageTransaction(imageId, filePath){
     // レコードを削除
     const result = await client.query(
     `DELETE FROM
-      images
+      image
     WHERE
       id = $1`,
      [imageId]

--- a/api/src/routers/image.js
+++ b/api/src/routers/image.js
@@ -1,5 +1,6 @@
 import express from "express";
-import { getImageById } from '../usecases/image.js';
+import { noRecord, noFile, success, rollbackError } from '../utils/image.js'
+import { getImageById, deleteImage, getDirPath } from '../usecases/image.js';
 
 const router = express.Router();
 
@@ -19,6 +20,31 @@ router.get("/:imageId", async (req, res) => {
     console.error("Error:", err);
     res.status(500).json({ error: "Internal Server Error" });
     };
+});
+
+// 画像の削除
+router.delete("/:imageId", async (req, res) => {
+  try {
+    const { imageId } = req.params;
+    if (!/^[0-9]+$/.test(imageId)) {
+      return res.status(400).json({ message: "Invalid imageId" });
+    };
+    const dirPath = getDirPath();
+    const result = await deleteImage(imageId, dirPath);
+    if (result === noFile || result === noRecord) {
+      return res.status(404).json({ message: "Resource not found" });
+    }
+    if (result === success) {
+      return res.status(204).end();
+    }
+    if (result === rollbackError){
+      throw new Error('rollbackError'); 
+    }
+    throw new Error(`Unexpected returnValue : ${String(result)}`);
+  } catch (err) {
+    console.error("Error:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  };
 });
 
 export default router;

--- a/api/src/routers/image.js
+++ b/api/src/routers/image.js
@@ -28,9 +28,13 @@ router.delete("/:imageId", async (req, res) => {
     const { imageId } = req.params;
     if (!/^[0-9]+$/.test(imageId)) {
       return res.status(400).json({ message: "Invalid imageId" });
-    };
+    }
     const dirPath = getDirPath();
     const result = await deleteImage(imageId, dirPath);
+    const validResults = [noFile, noRecord, success, rollbackError];
+    if (!validResults.includes(result)) {
+      throw new Error(`Unknown result: ${result}`);
+    }    
     if (result === noFile || result === noRecord) {
       return res.status(404).json({ message: "Resource not found" });
     }
@@ -40,7 +44,6 @@ router.delete("/:imageId", async (req, res) => {
     if (result === rollbackError){
       throw new Error('rollbackError'); 
     }
-    throw new Error(`Unexpected returnValue : ${String(result)}`);
   } catch (err) {
     console.error("Error:", err);
     res.status(500).json({ error: "Internal Server Error" });

--- a/api/src/routers/image.js
+++ b/api/src/routers/image.js
@@ -1,6 +1,6 @@
 import express from "express";
-import { noRecord, noFile, success } from '../utils/image.js'
-import { getImageById, deleteImage, getDirPath } from '../usecases/image.js';
+import { getImageById, removeImage, getDirPath, getImageFilePathIfExists } from '../usecases/image.js';
+import { NotFoundError, ValidationError, InternalError } from "../utils/commons/AppError.js";
 
 const router = express.Router();
 
@@ -22,29 +22,35 @@ router.get("/:imageId", async (req, res) => {
     };
 });
 
-// 画像の削除
 router.delete("/:imageId", async (req, res) => {
+  const { imageId } = req.params;
   try {
-    const { imageId } = req.params;
-    if (!/^[0-9]+$/.test(imageId)) {
-      return res.status(400).json({ message: "Invalid imageId" });
+    if (!/^\d+$/.test(imageId)) {
+      throw new ValidationError("Invalid imageId");
     }
+
     const dirPath = getDirPath();
-    const result = await deleteImage(imageId, dirPath);
-    const validResults = [noFile, noRecord, success];
-    if (!validResults.includes(result)) {
-      throw new Error(`Unknown result: ${result}`);
-    }    
-    if (result === noFile || result === noRecord) {
-      return res.status(404).json({ message: "Resource not found" });
+    const fileResult = await getImageFilePathIfExists(imageId, dirPath);
+    if (fileResult.isFailure()) throw fileResult.error;
+
+    const result = await removeImage(imageId, fileResult.data);
+    if (result.isFailure()) throw result.error;
+
+    return res.status(204).end();
+
+  } catch (error) {
+    console.error("Delete image error", error);
+
+    switch (true){
+      case error instanceof ValidationError:
+        return res.status(400).json({ error: error.message });
+      case error instanceof NotFoundError:
+        return res.status(404).json({ error: error.message });
+      case error instanceof InternalError:
+      default:
+        return res.status(500).json({ error: "Internal Server Error" });
     }
-    if (result === success) {
-      return res.status(204).end();
-    }
-  } catch (err) {
-    console.error("Error:", err);
-    res.status(500).json({ error: "Internal Server Error" });
-  };
+  }
 });
 
 export default router;

--- a/api/src/routers/image.js
+++ b/api/src/routers/image.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { noRecord, noFile, success, rollbackError } from '../utils/image.js'
+import { noRecord, noFile, success } from '../utils/image.js'
 import { getImageById, deleteImage, getDirPath } from '../usecases/image.js';
 
 const router = express.Router();
@@ -31,7 +31,7 @@ router.delete("/:imageId", async (req, res) => {
     }
     const dirPath = getDirPath();
     const result = await deleteImage(imageId, dirPath);
-    const validResults = [noFile, noRecord, success, rollbackError];
+    const validResults = [noFile, noRecord, success];
     if (!validResults.includes(result)) {
       throw new Error(`Unknown result: ${result}`);
     }    
@@ -40,9 +40,6 @@ router.delete("/:imageId", async (req, res) => {
     }
     if (result === success) {
       return res.status(204).end();
-    }
-    if (result === rollbackError){
-      throw new Error('rollbackError'); 
     }
   } catch (err) {
     console.error("Error:", err);

--- a/api/src/usecases/image.js
+++ b/api/src/usecases/image.js
@@ -16,7 +16,7 @@ export async function getImageById(imageId) {
 
 //画像の削除
 export async function deleteImage(imageId, dirPath) {
-  const files = fs.readdirSync(dirPath);
+  const files = await fs.readdirSync(dirPath);
   const file = files.find(file => path.parse(file).name === imageId);
   if (!file) {
     return noFile;

--- a/api/src/usecases/image.js
+++ b/api/src/usecases/image.js
@@ -1,7 +1,26 @@
-import { findImageById } from '../repositories/image.js';
+import path from 'path';
+import { promise as fs } from 'fs';
+import { noFile } from '../utils/image.js'
+import { findImageById, deleteImageTransaction } from '../repositories/image.js';
+
+//ファイルパスの取得
+export function getDirPath() {
+  return path.resolve("./uploads");
+};
 
 //画像の取得
 export async function getImageById(imageId) {
   const result = findImageById(imageId);
   return result; 
+};
+
+//画像の削除
+export async function deleteImage(imageId, dirPath) {
+  const files = fs.readdirSync(dirPath);
+  const file = files.find(file => path.parse(file).name === imageId);
+  if (!file) {
+    return noFile;
+  }
+  const filePath = path.join(dirPath, file);
+  return await deleteImageTransaction(imageId, filePath);
 };

--- a/api/src/usecases/image.js
+++ b/api/src/usecases/image.js
@@ -1,12 +1,24 @@
 import path from 'path';
-import { promise as fs } from 'fs';
-import { noFile } from '../utils/image.js'
-import { findImageById, deleteImageTransaction } from '../repositories/image.js';
+import { promises as fs } from 'fs';
+import { NotFoundError } from '../utils/commons/AppError.js';
+import * as imageRepository from '../repositories/image.js'
+import { findImageById } from '../repositories/image.js';
+import Result from '../utils/commons/Result.js';
 
 //ファイルパスの取得
 export function getDirPath() {
   return path.resolve("./uploads");
 };
+
+//画像の有無の確認
+export async function getImageFilePathIfExists(imageId, dirPath) {
+  const files = await fs.readdir(dirPath);
+  const file = files.find(file => path.parse(file).name === imageId);
+  if (!file) {
+    return Result.fail(new NotFoundError('File not found'));
+  }
+  return Result.ok(path.join(dirPath, file));
+} 
 
 //画像の取得
 export async function getImageById(imageId) {
@@ -15,12 +27,6 @@ export async function getImageById(imageId) {
 };
 
 //画像の削除
-export async function deleteImage(imageId, dirPath) {
-  const files = await fs.readdirSync(dirPath);
-  const file = files.find(file => path.parse(file).name === imageId);
-  if (!file) {
-    return noFile;
-  }
-  const filePath = path.join(dirPath, file);
-  return await deleteImageTransaction(imageId, filePath);
+export async function removeImage(imageId, filePath) {
+  return await imageRepository.deleteImage(imageId, filePath);
 };

--- a/api/src/utils/commons/AppError.js
+++ b/api/src/utils/commons/AppError.js
@@ -1,0 +1,25 @@
+export default class AppError extends Error {
+  constructor(message, cause = null) {
+    super(message, { cause });
+    this.name = new.target.name;
+    this.cause = cause;
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Resource not found", cause = null) {
+    super(message, cause);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message = "Validation error", cause = null) {
+    super(message, cause);
+  }
+}
+
+export class InternalError extends AppError {
+  constructor(message = "Internal server error", cause = null) {
+    super(message, cause);
+  }
+}

--- a/api/src/utils/commons/Result.js
+++ b/api/src/utils/commons/Result.js
@@ -1,0 +1,22 @@
+export default class Result {
+  constructor(data = null, error = null) {
+    this.data = data;
+    this.error = error;
+  }
+
+  static ok(data) {
+    return new Result(data, null);
+  }
+
+  static fail(error) {
+    return new Result(null, error);
+  }
+
+  isSuccess() {
+    return this.error === null;
+  }
+
+  isFailure() {
+    return this.error !== null;
+  }
+}

--- a/api/src/utils/image.js
+++ b/api/src/utils/image.js
@@ -1,6 +1,0 @@
-// 画像の削除
-export const deleteImageResult = Object.freeze({
-  success: Symbol('success'),
-  noFile: Symbol('noFile'),
-  noRecord: Symbol('noRecord'),
-});

--- a/api/src/utils/image.js
+++ b/api/src/utils/image.js
@@ -3,5 +3,4 @@ export const deleteImageResult = Object.freeze({
   success: Symbol('success'),
   noFile: Symbol('noFile'),
   noRecord: Symbol('noRecord'),
-  rollbackError: Symbol('rollbackError'),
 });

--- a/api/src/utils/image.js
+++ b/api/src/utils/image.js
@@ -1,0 +1,7 @@
+// 画像の削除
+export const deleteImageResult = Object.freeze({
+  success: Symbol('success'),
+  noFile: Symbol('noFile'),
+  noRecord: Symbol('noRecord'),
+  rollbackError: Symbol('rollbackError'),
+});


### PR DESCRIPTION
### 各層における実装の詳細は下記のとおりです

#### ルータ層
- ファイルパスの作成はビジネスロジックの責務のため、関数で呼び出すようにしました
- `Resource not found`をファイルまたはレコードがない状態としました

#### ユースケース層
- 特定の画像ファイルを探し、存在するかの確認はビジネスロジックの責務であるため、この層で実装しています
- ディレクトリファイルまでのパス生成は、ビジネスロジックにおける処理のため、この層で実装しています

#### リポジトリ層
- ファイルの削除に失敗した際、レコードを復元できるようにロールバック処理を実装しています

close #221
